### PR TITLE
Add placeholder image for missing item image

### DIFF
--- a/frontend/src/components/Editor.js
+++ b/frontend/src/components/Editor.js
@@ -52,7 +52,7 @@ class Editor extends React.Component {
       const item = {
         title: this.props.title,
         description: this.props.description,
-        image: this.props.image,
+        image: this.props.image || "/placeholder.png",
         tagList: this.props.tagList,
       };
 


### PR DESCRIPTION
# Description

Bugfix: Provide default image
<img width="1154" alt="Screen Shot 2022-08-04 at 8 50 39" src="https://user-images.githubusercontent.com/110542505/182863767-2d02aaa2-c828-48ef-9277-38ee1ee923d7.png">

